### PR TITLE
[update] devcontainer settings

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -36,8 +36,6 @@ RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - \
     && apt-get install -y nodejs \
     && npm install --global pyright
 
-RUN pip install -U pip
-
 # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
 RUN groupadd --gid $USER_GID $USERNAME \
     && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
@@ -55,13 +53,6 @@ RUN wget https://raw.githubusercontent.com/git/git/master/contrib/completion/git
     source ~/.git-prompt.sh\n\
     export PS1='\\[\\e]0;\\u@\\h: \\w\\a\\]\${debian_chroot:+(\$debian_chroot)}\\[\\033[01;32m\\]\\u\\[\\033[00m\\]:\\[\\033[01;34m\\]\\w\\[\\033[00m\\]\\[\\033[1;30m\\]\$(__git_ps1)\\[\\033[0m\\] \\$ '\n\
     " >>  /home/vscode/.bashrc
-
-# copy requirements files
-COPY ./requirements.txt /tmp/requirements.txt
-COPY ./requirements-dev.txt /tmp/requirements-dev.txt
-
-# library install
-RUN pip install -r /tmp/requirements.txt -r /tmp/requirements-dev.txt
 
 ENV DEBIAN_FRONTEND=
 CMD ["/bin/bash"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,11 +25,10 @@
   // Uncomment the next line if you want to keep your containers running after VS Code shuts down.
   "shutdownAction": "stopCompose",
 
-  // Uncomment the next line to run commands after the container is created - for example installing curl.
-  // "postCreateCommand": "apt-get update && apt-get install -y curl",
-
   // Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
   "remoteUser": "vscode",
+
+  // Uncomment the next line to run commands after the container is created - for example installing curl.
   "postCreateCommand": "pip install -U pip && pip install -r requirements.txt -r requirements-dev.txt",
   "postAttachCommand": "pip install -U pip && pip install -r requirements.txt -r requirements-dev.txt",
   // Set *default* container specific settings.json values on container create.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,42 +2,88 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.128.0/containers/docker-existing-docker-compose
 // If you want to run as a non-root user in the container, see .devcontainer/docker-compose.yml.
 {
-	"name": "Existing Docker Compose (Extend)",
+  "name": "homeru kun",
 
-	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
-	// The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
-	"dockerComposeFile": [
-		"../docker-compose.yml",
-	],
+  // Update the 'dockerComposeFile' list if you have more compose files or use different names.
+  // The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
+  "dockerComposeFile": ["../docker-compose.yml"],
 
-	// The 'service' property is the name of the service for the container that VS Code should
-	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
-	"service": "homeru_bot",
+  // The 'service' property is the name of the service for the container that VS Code should
+  // use. Update this value and .devcontainer/docker-compose.yml to the real service name.
+  "service": "homeru_bot",
 
-	// The optional 'workspaceFolder' property is the path VS Code should open by default when
-	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
-	"workspaceFolder": "/homeru_bot",
+  // The optional 'workspaceFolder' property is the path VS Code should open by default when
+  // connected. This is typically a file mount in .devcontainer/docker-compose.yml
+  "workspaceFolder": "/homeru_bot",
 
-	// Set *default* container specific settings.json values on container create.
-	"settings": {
-		"terminal.integrated.shell.linux": null
-	},
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
 
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": []
+  // Uncomment the next line if you want start specific services in your Docker Compose config.
+  // "runServices": [],
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
+  // Uncomment the next line if you want to keep your containers running after VS Code shuts down.
+  "shutdownAction": "stopCompose",
 
-	// Uncomment the next line if you want start specific services in your Docker Compose config.
-	// "runServices": [],
+  // Uncomment the next line to run commands after the container is created - for example installing curl.
+  // "postCreateCommand": "apt-get update && apt-get install -y curl",
 
-	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.
-	// "shutdownAction": "none",
+  // Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+  "remoteUser": "vscode",
+  "postCreateCommand": "pip install -U pip && pip install -r requirements.txt -r requirements-dev.txt",
+  "postAttachCommand": "pip install -U pip && pip install -r requirements.txt -r requirements-dev.txt",
+  // Set *default* container specific settings.json values on container create.
+  "settings": {
+    "files.eol": "\n",
+    "files.insertFinalNewline": true,
+    "files.trimTrailingWhitespace": true,
+    "terminal.integrated.shell.linux": "/bin/bash",
+    "python.pythonPath": "/usr/local/bin/python",
+    "python.linting.pylintEnabled": false,
+    "python.linting.enabled": true,
+    "python.linting.flake8Enabled": true,
+    "python.linting.flake8Args": ["--config=.flake8"],
+    "python.linting.lintOnSave": true,
+    "python.formatting.provider": "black",
+    "python.formatting.blackArgs": [
+      "--line-length",
+      "100",
+      "--skip-string-normalization"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.nosetestsEnabled": false,
+    "python.testing.pytestEnabled": false,
+    "python.analysis.diagnosticMode": "workspace",
+    "python.jediEnabled": false,
+    "python.languageServer": "Pylance",
+    "python.analysis.typeCheckingMode": "basic",
+    "vsintellicode.python.completionsEnabled": true,
+    "vsintellicode.features.python.deepLearning": "enabled",
+    "vsintellicode.modify.editor.suggestSelection": "enabled",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": true
+    },
+    "[python]": {
+      "editor.tabSize": 4
+    },
+    "[json]": {
+      "editor.tabSize": 2
+    },
+    "[yaml]": {
+      "editor.tabSize": 2
+    },
+    "autoDocstring.docstringFormat": "numpy",
+    "autoDocstring.startOnNewLine": true
+  },
 
-	// Uncomment the next line to run commands after the container is created - for example installing curl.
-	// "postCreateCommand": "apt-get update && apt-get install -y curl",
-
-	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
-	// "remoteUser": "vscode"
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": [
+    "ms-python.python",
+    "esbenp.prettier-vscode",
+    "njpwerner.autodocstring",
+    "eamodio.gitlens",
+    "ms-python.vscode-pylance",
+    "VisualStudioExptTeam.vscodeintellicode"
+  ]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,7 +30,7 @@
 
   // Uncomment the next line to run commands after the container is created - for example installing curl.
   "postCreateCommand": "pip install -U pip && pip install -r requirements.txt -r requirements-dev.txt",
-  "postAttachCommand": "pip install -U pip && pip install -r requirements.txt -r requirements-dev.txt",
+
   // Set *default* container specific settings.json values on container create.
   "settings": {
     "files.eol": "\n",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
   // "runServices": [],
 
   // Uncomment the next line if you want to keep your containers running after VS Code shuts down.
-  "shutdownAction": "stopCompose",
+  // "shutdownAction": "stopCompose",
 
   // Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
   "remoteUser": "vscode",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -73,7 +73,7 @@
     "[yaml]": {
       "editor.tabSize": 2
     },
-    "autoDocstring.docstringFormat": "numpy",
+    "autoDocstring.docstringFormat": "google",
     "autoDocstring.startOnNewLine": true
   },
 


### PR DESCRIPTION
closed #1 

## 概要
- #1 を参照

## 詳細
- Dockerfile
  - pip自体のアップデートと、依存ライブラリのinstallはcontainer起動時に行うように変更
  - 既存の方法だとrequirements.txtの変更が適用されなかったため
- .devcontainer/devcontainer.json
  - ほぼ全部記載しているので直接聞いてください
  - [ドキュメント](https://code.visualstudio.com/docs/remote/devcontainerjson-reference)

## レビューポイント（意見が欲しい所）
- blackの設定
  - ダブルクォーテーションにするか、シングルにするか
    - 私の一押しはblackに従ってダブルなのですが、所属組織ではシングルが推奨との事なのでシングルにしています
      - https://github.com/psf/black/issues/118
      - ※↑長いですが是非読んでいただきたい！（英語でという事ではない）
    - シングルにした場合、ダブルクォーテーションで書いた場合にblackで自動修正は行われません
      - ダブルにしてシングルで書いた場合には修正されます
      - ただ、flake8で指摘されるので手動で直す必要があります
  - 行の長さ
    - 私の趣味で100としています
    - 長すぎると読みにくく、短すぎると改行が多くなるので読みにくい
    - pep8だと79
      - https://www.python.org/dev/peps/pep-0008/#maximum-line-length
    - blackだと88
      - https://black.readthedocs.io/en/stable/the_black_code_style.html#line-length
    - google style guideだと80
      - https://google.github.io/styleguide/pyguide.html#32-line-length
    - 新しいライブラリだと120が多い印象
      - 個人的には長すぎる印象
- VS Codeの設定（.devcontainer.json のsettings）
  - 個人の趣味は排除し、必要なものだけ設定した認識
- VS Codeの拡張機能
  - 必要最低限 + α
  - 趣味の範囲のものは入れていません

## やらなかったこと
- `.env` が必要な事をREADMEに記載
  - 現状、 `.env` が存在しないと起動ができない（空ファイルでOK）
  - #2 で対応する
