### PR TITLE
[add] mount .ssh folder

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,14 @@
-version: '3'
+version: "3"
 services:
   homeru_bot:
-    build: 
+    build:
       context: .
       dockerfile: .devcontainer/Dockerfile
       args:
         WORKDIR: /homeru_bot
     volumes:
       - .:/homeru_bot
+      - ${USERPROFILE-~}/.ssh:/home/vscode/.ssh
     image: homeru_bot-image
     container_name: homeru_bot-container
     tty: true


### PR DESCRIPTION
closed #11 

## 概要
- `${USERPROFILE-~}/.ssh` を `/home/vscode/.ssh` にマウントする事で、ローカルの認証キーをコンテナ内に持ち込みます

## 注意点
- `.ssh` 以外に配置していてconfigなどで別のパスを指すような運用をしている場合には動作しません
  - レアケースがどうかは私は判断できないですが、業務でも同様のコードを使用しており1名いました
    - 対応としては.ssh以下に配置しなおしてもらいました
