### PR TITLE
[fixed] black settings for GitHub Actions

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -26,5 +26,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-check
-          black_args: ". --check --diff --line-length 100 --skip-string-normalization"
+          args: ". --check --diff --line-length 100 --skip-string-normalization"
           fail_on_error: true

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -22,9 +22,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-dev.txt
       - name: Run black with review dog
-        uses: reviewdog/action-black@v1
+        uses: reviewdog/action-black@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-check
-          args: ". --check --diff --line-length 100 --skip-string-normalization"
+          black_args: "--diff --line-length 100 --skip-string-normalization"
           fail_on_error: true

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -21,11 +21,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-dev.txt
-      - name: Lint with black
-        run: black --check **/*.py
       - name: Run black with review dog
         uses: reviewdog/action-black@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-check
+          black_args: ". --check --diff --line-length 100 --skip-string-normalization"
           fail_on_error: true


### PR DESCRIPTION
#8 で追加したblackのGitHub Actionsの設定が誤っているため意図する形で動作していない。
そのため、正しく動作するように修正。

## レビューメモ
- 公式のREADMEには `@v1` となっているが、最新版はv2
- v1の場合、blackに渡す引数は `args` という名称
- かなりハマったので公式にPR出しておいた
  - https://github.com/reviewdog/action-black/pull/37

## 関連
- https://github.com/reviewdog/action-black