### PR TITLE
[add] work directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# work directory
+work


### PR DESCRIPTION
## 概要
workという名称のdirecotoryをgit管理しないように対応

## 詳細
個人的な趣味ではあるものの、ワークスペース内でコードを試したい事がある。
そういった場合に、workというディレクトリの下にファイルを作る事で試すことが多々あるため、追加したい。

具体的には `test.ipynb` などノートブックを作ってその中で処理を試したりなど