### PR TITLE
[fixed] black settings

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -26,5 +26,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-check
-          black_args: "--diff --line-length 100 --skip-string-normalization"
+          black_args: "--line-length 100 --skip-string-normalization"
           fail_on_error: true


### PR DESCRIPTION
## 概要
- #24 の中で判明したblackの設定ミスの修正です

## 詳細
- diffオプションがあることで、blackが出力するメッセージをパースできず、指摘箇所がわからない場合がある
- 具体例
  - https://github.com/yamazaki-seiya/homeru_kun/runs/2454499387

## 関連
- https://github.com/yamazaki-seiya/homeru_kun/pull/24#issuecomment-828149147
- https://github.com/yamazaki-seiya/homeru_kun/pull/24#issuecomment-828266888
