### PR TITLE
メンション間に記号や空欄を入れずに投稿された場合にも、全てのユーザーIDが取得されるように改修した

### DIFF
--- a/plugins/botmodule.py
+++ b/plugins/botmodule.py
@@ -8,13 +8,6 @@ from slackbot.bot import listen_to
 # 複数のユーザーIDが1つの文字列に含まれる場合に、1ユーザーIDずつ分けて抽出するため
 _EXTRACT_USER_PATTERN = re.compile(r'<@\w+>')
 
-# メンションされたユーザーを抽出するための正規表現パターン
-# メンションユーザーの区切り文字としては現状以下のパターンが大多数を占めるが他の文字も考慮した
-#   - 半角スペース、'\xa0'（ノーブレークスペース）
-#
-# 投稿メッセージ例: @user1 @user2,@user3;@user4 messages
-_MENTION_SPLIT_PATTERN = re.compile(r'[\xa0| |,|;]')
-
 
 @listen_to(r'.*@.*')
 def homeru_post(message):
@@ -68,19 +61,11 @@ def _create_random_element_list(path, user_num):
 
 def _extract_users(message):
     """メッセージからメンションするためのユーザーのリストを抽出する"""
-    splitted_message = re.split(_MENTION_SPLIT_PATTERN, message)
-    print(f'splitted_message:{splitted_message}')
 
     # TODO:メンションされたユーザーが重複する場合に返答は1回にするかを検討する
-    user_list = []
-    for words in splitted_message:
-        print('words:', words)
-        # メンションユーザーの文字列にマッチする文字列を全て取得するため
-        menttioned_user_list = _EXTRACT_USER_PATTERN.findall(words)
-        print('menttioned_user_list:', menttioned_user_list)
-        for menttioned_user in menttioned_user_list:
-            user_list.append(menttioned_user)
+    user_list = _EXTRACT_USER_PATTERN.findall(message)
     print('user_list:', user_list)
+
     return user_list
 
 

--- a/plugins/botmodule.py
+++ b/plugins/botmodule.py
@@ -5,7 +5,8 @@ import re
 
 from slackbot.bot import listen_to
 
-_EXTRACT_USER_PATTERN = re.compile(r'<@.*>')
+# 複数のユーザーIDが1つの文字列に含まれる場合に、1ユーザーIDずつ分けて抽出するため
+_EXTRACT_USER_PATTERN = re.compile(r'<@[a-zA-Z_0-9]{1,}>')
 
 # メンションされたユーザーを抽出するための正規表現パターン
 # メンションユーザーの区切り文字としては現状以下のパターンが大多数を占めるが他の文字も考慮した
@@ -20,7 +21,6 @@ def homeru_post(message):
     """
     メンション付きの投稿がされた場合に、メッセージ内のメンションされた人をほめる機能
     """
-
     _validation_bot_subtype(message)
 
     # このボットの投稿に反応しないようにする
@@ -74,10 +74,13 @@ def _extract_users(message):
     # TODO:メンションされたユーザーが重複する場合に返答は1回にするかを検討する
     user_list = []
     for words in splitted_message:
-        menttioned_user = _EXTRACT_USER_PATTERN.match(words)
-        if menttioned_user is not None:
-            user_list.append(menttioned_user.group())
-
+        print('words:', words)
+        # メンションユーザーの文字列にマッチする文字列を全て取得するため
+        menttioned_user_list = _EXTRACT_USER_PATTERN.findall(words)
+        print('menttioned_user_list:', menttioned_user_list)
+        for menttioned_user in menttioned_user_list:
+            user_list.append(menttioned_user)
+    print('user_list:', user_list)
     return user_list
 
 

--- a/plugins/botmodule.py
+++ b/plugins/botmodule.py
@@ -6,7 +6,7 @@ import re
 from slackbot.bot import listen_to
 
 # 複数のユーザーIDが1つの文字列に含まれる場合に、1ユーザーIDずつ分けて抽出するため
-_EXTRACT_USER_PATTERN = re.compile(r'<@[a-zA-Z_0-9]{1,}>')
+_EXTRACT_USER_PATTERN = re.compile(r'<@\w+>')
 
 # メンションされたユーザーを抽出するための正規表現パターン
 # メンションユーザーの区切り文字としては現状以下のパターンが大多数を占めるが他の文字も考慮した


### PR DESCRIPTION
## 概要
参考 close #38 
メンションされたユーザーＩＤのみを取得する動作が期待されるが、複数メンションの間の記号や空白によって、下記の問題が発生したため対応した。
問題例：
・ユーザーID以外の文字列も混入した文字列が取得されてしまう　
　例）西谷さん<@UELMLSER>
・複数のユーザーIDが分割されず1つの文字列として取得してしまう　
　例）<@UEMLMDS><@RIFGSDG>

改修内容：
・投稿文を正規表現を用いて分割する部分は変えず、分割した後の各要素が上記の問題を含む場合の対応を実装した。
・分割した後の要素の文字列から、ユーザーIDを判定する正規表現パターンを修正
　<@任意の文字列0文字以上> ➡ <@英数字一文字以上>
・分割した後の要素の文字列に、複数のユーザーIDが分割されず1つの文字列として取得されている場合、これを分割して全てのユーザーIDを取得する仕様に変更


## レビューメモ
・投稿文を正規表現を用いて分割する部分を修正することで、もっとシンプルに書けるかもしれないです。
・for文が入れ子になっているため、よりよい表現があればご指摘ください。
（・本件とは関係ないですが、menttionの綴りをmentionに修正してもいいかもと思いました）