### PR TITLE
チャネル参加時の自動メッセージとbotからのメッセージに反応しない仕様に修正

### DIFF
--- a/plugins/botmodule.py
+++ b/plugins/botmodule.py
@@ -35,9 +35,9 @@ def homeru_post(message):
 
 def _validation_bot_subtype(message):
     """ボットのメッセージか判定する"""
-    print("botのsubtype確認:", message.body)
+    print('botのsubtype確認:', message.body)
     print(
-        "subtypeの判定結果:",
+        'subtypeの判定結果:',
         ('subtype' in message.body)
         and (message.body['subtype'] in ['bot_message', 'channel_join']),
     )

--- a/plugins/botmodule.py
+++ b/plugins/botmodule.py
@@ -5,7 +5,7 @@ import re
 
 from slackbot.bot import listen_to
 
-# slackへの投稿コメントからユーザーIDを抽出するための正規表現パターン
+# 複数のユーザーIDが1つの文字列に含まれる場合に、1ユーザーIDずつ分けて抽出するため
 _EXTRACT_USER_PATTERN = re.compile(r'<@\w+>')
 
 

--- a/plugins/botmodule.py
+++ b/plugins/botmodule.py
@@ -14,8 +14,8 @@ def homeru_post(message):
     """
     メンション付きの投稿がされた場合に、メッセージ内のメンションされた人をほめる機能
     """
-    # このボットとslackからの参加メッセージに反応しないようにする
-    if not  _validation_bot_subtype(message):
+    # 反応対象のメッセージのみに反応するようにする
+    if not  _is_target_message(message):
         text = message.body['text']
         print(f'ポストされたメッセージ: {text}')
         user_list = _extract_users(text)
@@ -30,17 +30,14 @@ def homeru_post(message):
         )
 
 
-def _validation_bot_subtype(message):
-    """ボットのメッセージか判定する"""
+def _is_target_message(message):
+    """ボットの反応対象のメッセージかを判定する"""
     print('botのsubtype確認:', message.body)
-    print(
-        'subtypeの判定結果:',
-        ('subtype' in message.body)
-        and (message.body['subtype'] in ['bot_message', 'channel_join']),
-    )
-    return ('subtype' in message.body) and (
+    result = ('subtype' in message.body) and (
         message.body['subtype'] in ['bot_message', 'channel_join']
     )
+    print(f"result: {result}")
+    return result
 
 
 def _create_random_element_list(path, user_num):

--- a/plugins/botmodule.py
+++ b/plugins/botmodule.py
@@ -14,33 +14,36 @@ def homeru_post(message):
     """
     メンション付きの投稿がされた場合に、メッセージ内のメンションされた人をほめる機能
     """
-    _validation_bot_subtype(message)
+    # このボットとslackからの参加メッセージに反応しないようにする
+    if _validation_bot_subtype(message):
+        pass
 
-    # このボットの投稿に反応しないようにする
-    _add_bot_message_subtype(message)
+    else:
+        text = message.body['text']
+        print(f'ポストされたメッセージ: {text}')
+        user_list = _extract_users(text)
+        print(f'user_num: {len(user_list)}')
 
-    text = message.body['text']
-    print(f'ポストされたメッセージ: {text}')
-    user_list = _extract_users(text)
-    print(f'user_num: {len(user_list)}')
+        post_message = _get_post_message(user_list)
 
-    post_message = _get_post_message(user_list)
-
-    # スレッド内のユーザーの返信に、スレッドの外で反応すると会話の流れがわかりにくいため
-    message.send(
-        post_message, thread_ts=message.body['thread_ts'] if 'thread_ts' in message.body else None
-    )
+        # スレッド内のユーザーの返信に、スレッドの外で反応すると会話の流れがわかりにくいため
+        message.send(
+            post_message,
+            thread_ts=message.body['thread_ts'] if 'thread_ts' in message.body else None,
+        )
 
 
 def _validation_bot_subtype(message):
     """ボットのメッセージか判定する"""
-    return ('subtype' in message.body) and (message.body['subtype'] == 'bot_message')
-
-
-def _add_bot_message_subtype(message):
-    """ボットのメッセージだとわかるように判別をつける"""
-    message.body['subtype'] = 'bot_message'
-    return message
+    print("botのsubtype確認:", message.body)
+    print(
+        "subtypeの判定結果:",
+        ('subtype' in message.body)
+        and (message.body['subtype'] in ['bot_message', 'channel_join']),
+    )
+    return ('subtype' in message.body) and (
+        message.body['subtype'] in ['bot_message', 'channel_join']
+    )
 
 
 def _create_random_element_list(path, user_num):

--- a/plugins/botmodule.py
+++ b/plugins/botmodule.py
@@ -16,18 +16,19 @@ def homeru_post(message):
     """
     # 反応対象のメッセージのみに反応するようにする
     if _is_target_message(message):
-        text = message.body['text']
-        print(f'ポストされたメッセージ: {text}')
-        user_list = _extract_users(text)
-        print(f'user_num: {len(user_list)}')
+        return
+    text = message.body['text']
+    print(f'ポストされたメッセージ: {text}')
+    user_list = _extract_users(text)
+    print(f'user_num: {len(user_list)}')
 
-        post_message = _get_post_message(user_list)
+    post_message = _get_post_message(user_list)
 
-        # スレッド内のユーザーの返信に、スレッドの外で反応すると会話の流れがわかりにくいため
-        message.send(
-            post_message,
-            thread_ts=message.body['thread_ts'] if 'thread_ts' in message.body else None,
-        )
+    # スレッド内のユーザーの返信に、スレッドの外で反応すると会話の流れがわかりにくいため
+    message.send(
+        post_message,
+        thread_ts=message.body['thread_ts'] if 'thread_ts' in message.body else None,
+    )
 
 
 def _is_target_message(message):

--- a/plugins/botmodule.py
+++ b/plugins/botmodule.py
@@ -15,7 +15,7 @@ def homeru_post(message):
     メンション付きの投稿がされた場合に、メッセージ内のメンションされた人をほめる機能
     """
     # 反応対象のメッセージのみに反応するようにする
-    if not  _is_target_message(message):
+    if not _is_target_message(message):
         text = message.body['text']
         print(f'ポストされたメッセージ: {text}')
         user_list = _extract_users(text)
@@ -36,7 +36,7 @@ def _is_target_message(message):
     result = ('subtype' in message.body) and (
         message.body['subtype'] in ['bot_message', 'channel_join']
     )
-    print(f"result: {result}")
+    print(f'result: {result}')
     return result
 
 

--- a/plugins/botmodule.py
+++ b/plugins/botmodule.py
@@ -15,10 +15,7 @@ def homeru_post(message):
     メンション付きの投稿がされた場合に、メッセージ内のメンションされた人をほめる機能
     """
     # このボットとslackからの参加メッセージに反応しないようにする
-    if _validation_bot_subtype(message):
-        pass
-
-    else:
+    if not  _validation_bot_subtype(message):
         text = message.body['text']
         print(f'ポストされたメッセージ: {text}')
         user_list = _extract_users(text)

--- a/plugins/botmodule.py
+++ b/plugins/botmodule.py
@@ -32,7 +32,7 @@ def homeru_post(message):
 
 def _is_target_message(message):
     """ボットの反応対象のメッセージかを判定する"""
-    print('botのsubtype確認:', message.body)
+    # 投稿がbotかslackからの自動投稿の場合、message.bodyの辞書にsubtypeキーが存在する
     result = ('subtype' in message.body) and (
         message.body['subtype'] in ['bot_message', 'channel_join']
     )

--- a/plugins/botmodule.py
+++ b/plugins/botmodule.py
@@ -5,7 +5,7 @@ import re
 
 from slackbot.bot import listen_to
 
-# 複数のユーザーIDが1つの文字列に含まれる場合に、1ユーザーIDずつ分けて抽出するため
+# slackへの投稿コメントからユーザーIDを抽出するための正規表現パターン
 _EXTRACT_USER_PATTERN = re.compile(r'<@\w+>')
 
 

--- a/plugins/botmodule.py
+++ b/plugins/botmodule.py
@@ -15,7 +15,7 @@ def homeru_post(message):
     メンション付きの投稿がされた場合に、メッセージ内のメンションされた人をほめる機能
     """
     # 反応対象のメッセージのみに反応するようにする
-    if _is_target_message(message):
+    if not _is_target_message(message):
         return
     text = message.body['text']
     print(f'ポストされたメッセージ: {text}')

--- a/plugins/botmodule.py
+++ b/plugins/botmodule.py
@@ -15,7 +15,7 @@ def homeru_post(message):
     メンション付きの投稿がされた場合に、メッセージ内のメンションされた人をほめる機能
     """
     # 反応対象のメッセージのみに反応するようにする
-    if not _is_target_message(message):
+    if _is_target_message(message):
         text = message.body['text']
         print(f'ポストされたメッセージ: {text}')
         user_list = _extract_users(text)
@@ -33,8 +33,8 @@ def homeru_post(message):
 def _is_target_message(message):
     """ボットの反応対象のメッセージかを判定する"""
     # 投稿がbotかslackからの自動投稿の場合、message.bodyの辞書にsubtypeキーが存在する
-    result = ('subtype' in message.body) and (
-        message.body['subtype'] in ['bot_message', 'channel_join']
+    result = not (
+        ('subtype' in message.body) and (message.body['subtype'] in ['bot_message', 'channel_join'])
     )
     print(f'result: {result}')
     return result


### PR DESCRIPTION
## 概要
チャネル参加時に、「@XXX が参加しました」というslackからの自動メッセージに対して、botがメッセージを返す仕様になっていたため、改修した。 

## 詳細
チャネル参加時の自動メッセージは、message.body（辞書型）に、キー"subtype"が発生し、値が”channel_join”であることから下記の点を改修。
・既存_validate_bot_subtype関数の関数名をis_target_messageに変更し、ボットが反応する対象のメッセージかを判定する関数とした。
・上記関数で、ボットの反応対象のメッセージの場合の返り値がTrueになるようにした。
・上記関数で、判定条件に、「'subtype'キーがあること」と「subtypeキーの値が'channel_join'であること」とした。
・homeru_post関数内で、is_target_message関数で投稿をボットの反応対象か判定するプロセスを追加した。

## その他
- なお、本改修により、ウィークリーレポートの投稿に対しても反応しないようになる。
- 関連issue
  - close #51 
