### PR TITLE
週次集計結果コメントを妹仕様に変更

### DIFF
--- a/analytics.py
+++ b/analytics.py
@@ -73,8 +73,10 @@ def _get_posts_with_reaction(trace_back_days: int) -> List[Dict]:
 def _post_start_message() -> None:
     """レポート最初のコメントを投稿する"""
     message = '''
-        先週もようがんばったな:kissing_cat:ノビルくんの弟からウィークリーレポートのお知らせやで～
-        先週みんなが送ってくれた「褒め言葉」の中で、一番多くのスタンプを集めたウィークリーベスト褒めエピソードはこれや！:cv2_res_pect:
+        やっほー:blossom:ノビルくんの妹やで:ribbon:
+        うちからウィークリーレポートをおしらせするで:laughing:
+        先週もみんなようがんばってくれたみたいでほんま嬉しいわ～:sunflower:
+        みんなが送ってくれた「褒め言葉」の中で、一番多くのスタンプを集めたウィークリーベスト褒めエピソードはこれや！:cv2_res_pect:
     '''
     _post_message(message)
 


### PR DESCRIPTION
## 概要
- 週次集計結果コメントを妹キャラに合わせるためanalytics.py の中のコメント投稿用関数_post_start_message()のmessageを妹仕様(詳細は#54)に変更
- #57では間違えたブランチを切ってしまったので、再度PR作成した

## 詳細
- 週次集計のためのボットがノビルくん弟とは別立てのノビルくんの妹botとなった
- 当初の計画では同じボットを利用する想定であったため、_post_start_messageで投稿される週次集計結果の発表コメントmessageについてノビルくん弟が話す内容となっていた。
- しかしながら、もとのコメントではキャラブレが発生するため、_post_start_messageのmessageの内容を妹仕様へと変更することが必要となった
- そこでanalytics.py の関数_post_start_message()のmessageを妹仕様(詳細は#54)に変更
- をしようとしたが、#57では誤った位置からブランチをはやしてしまったため、再度切り直して再度PRしなおした。


## その他
- 関連issue #54
  - close #57 